### PR TITLE
Fix small error in the documentation

### DIFF
--- a/http-requests-documentation/src/docs/components/httpresponse.adoc
+++ b/http-requests-documentation/src/docs/components/httpresponse.adoc
@@ -14,7 +14,7 @@
 |===
 
 IMPORTANT: To ensure that all resources used during the request are released, it is critical that the response is
-closed via the `HttpRequest.close()` method once the response is no longer needed.
+closed via the `HttpResponse.close()` method once the response is no longer needed.
 
 ==== Response Entities
 


### PR DESCRIPTION
You're supposed to `.close()` the `HttpResponse`, not the `HttpRequest`.